### PR TITLE
MM-19525 Trim contents of code spans

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -763,12 +763,12 @@ InlineLexer.prototype.output = function(src) {
       continue;
     }
 
-    // code
+    // codespan
     if (cap = this.rules.code.exec(src)) {
       src = src.substring(cap[0].length);
       tokens.push({
         type: 'code',
-        text: escape(cap[2], true)
+        text: escape(cap[2].trim(), true)
       });
       continue;
     }

--- a/test/tests/mm19525_codespan__whitespace.html
+++ b/test/tests/mm19525_codespan__whitespace.html
@@ -1,0 +1,1 @@
+<p>This sentence with <code>in-line code</code> should appear on one line.</p>

--- a/test/tests/mm19525_codespan__whitespace.text
+++ b/test/tests/mm19525_codespan__whitespace.text
@@ -1,0 +1,3 @@
+This sentence with `
+in-line code
+` should appear on one line.


### PR DESCRIPTION
https://github.com/mattermost/marked/pull/14 changed the regex for code spans so that it captures more whitespace around the contents of the code span. Trimming it matches what the upstream library does now as well

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-19525