### PR TITLE
MM-19964 Trim code block language

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -203,7 +203,7 @@ Lexer.prototype.token = function(src, top, bq, links, depth) {
       src = src.substring(cap[0].length);
       tokens.push({
         type: 'code',
-        lang: cap[2],
+        lang: cap[2] ? cap[2].trim() : cap[2],
         text: cap[3] || ''
       });
       continue;


### PR DESCRIPTION
The regex used to capture code blocks used to not include whitespace around the language tag, but that got changed so that it now includes whitespace around the language. To account for that, we need to trim the language tag before passing it off to the renderer.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-19964