### PR TITLE
MM-18541 Use start attribute for initial list index

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -302,7 +302,8 @@ Lexer.prototype.token = function(src, top, bq, links, depth) {
 
       tokens.push({
         type: 'list_start',
-        ordered: ordered
+        ordered: ordered,
+        start: ordered ? parseInt(bull) : 0
       });
 
       // Get each top-level item.
@@ -981,9 +982,16 @@ Renderer.prototype.hr = function() {
   return this.options.xhtml ? '<hr/>\n' : '<hr>\n';
 };
 
-Renderer.prototype.list = function(body, ordered) {
+Renderer.prototype.list = function(body, ordered, start) {
   var type = ordered ? 'ol' : 'ul';
-  return '<' + type + '>\n' + body + '</' + type + '>\n';
+
+  var out = '<' + type;
+  if (start && start !== 1) {
+    out += 'start="' + start + '"';
+  }
+  out += '>\n' + body + '</' + type + '>\n';
+
+  return out;
 };
 
 Renderer.prototype.listitem = function(text) {
@@ -1208,14 +1216,15 @@ Parser.prototype.tok = function() {
       return this.renderer.blockquote(body);
     }
     case 'list_start': {
-      var body = ''
-        , ordered = this.token.ordered;
+      body = '';
+      var ordered = this.token.ordered,
+          start = this.token.start;
 
       while (this.next().type !== 'list_end') {
         body += this.tok();
       }
 
-      return this.renderer.list(body, ordered);
+      return this.renderer.list(body, ordered, start);
     }
     case 'list_item_start': {
       var body = ''

--- a/test/tests/mm18541_list_starting_values.html
+++ b/test/tests/mm18541_list_starting_values.html
@@ -1,0 +1,23 @@
+<ol>
+    <li>one</li>
+    <li>two</li>
+    <li>three</li>
+</ol>
+
+<ol start="100">
+    <li>one hundred</li>
+    <li>one hundred and one</li>
+    <li>one hundred and two</li>
+</ol>
+
+<ol start="99999">
+    <li>ninety-nine thousand nine hundred and nine</li>
+    <li>one hundred thousand</li>
+    <li>one hundred thousand and one</li>
+</ol>
+
+<ul>
+    <li>a</li>
+    <li>b</li>
+    <li>c</li>
+</ul>

--- a/test/tests/mm18541_list_starting_values.text
+++ b/test/tests/mm18541_list_starting_values.text
@@ -1,0 +1,18 @@
+1. one
+1. two
+1. three
+
+
+100. one hundred
+1. one hundred and one
+1. one hundred and two
+
+
+99999. ninety-nine thousand nine hundred and nine
+1. one hundred thousand
+1. one hundred thousand and one
+
+
+- a
+- b
+- c

--- a/test/tests/ordered_and_unordered_lists.html
+++ b/test/tests/ordered_and_unordered_lists.html
@@ -146,3 +146,25 @@ back.</p></li>
 
 <p>that</p></li>
 </ul>
+
+
+<p>Ordered lists start from initial number:</p>
+
+<ol start="3">
+<li>Three</li>
+<li>Four</li>
+</ol>
+
+
+<p>Ordered lists continue with initial number:</p>
+
+<ol start="3">
+<li>First</li>
+<li>Second:
+<ul>
+<li>Fee</li>
+<li>Fie</li>
+<li>Foe</li>
+</ul></li>
+<li>Third</li>
+</ol>

--- a/test/tests/ordered_and_unordered_lists.text
+++ b/test/tests/ordered_and_unordered_lists.text
@@ -129,3 +129,17 @@ This was an error in Markdown 1.0.1:
 	*	sub
 
 	that
+
+Ordered lists start from initial number:
+
+3. Three
+1. Four
+
+Ordered lists continue with initial number:
+
+3. First
+4. Second:
+	* Fee
+	* Fie
+	* Foe
+5. Third

--- a/test/tests/test-markdown-lists.md.html
+++ b/test/tests/test-markdown-lists.md.html
@@ -1,6 +1,6 @@
 <h3 id="single-item-ordered-list">Single-Item Ordered List</h3>
 
-<ol>
+<ol start="7">
 	<li>Single Item</li>
 </ol>
 
@@ -122,10 +122,10 @@
 		<ol>
 			<li>
 				November
-				<ol>
+				<ol start="4">
 					<li>
 						Oscar
-						<ol>
+						<ol start="5">
 							<li>Papa</li>
 						</ol>
 					</li>
@@ -175,6 +175,6 @@
 	<li>One</li>
 </ol>
 <p>List B:</p>
-<ol>
+<ol start="2">
 	<li>Two</li>
 </ol>


### PR DESCRIPTION
We currently set the value of the first list item to support lists that start at a number other than one, but using the `start` attribute on the `ol` tag is better for this. Having the index of the first item at the list level also saves us some hacky logic in our code to calculate that based on the children of that component.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-18541