### PR TITLE
MM-32645: correct rendering of inline links

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -50,6 +50,8 @@ block._tag = '(?!(?:'
   + '|var|samp|kbd|sub|sup|i|b|u|mark|ruby|rt|rp|bdi|bdo'
   + '|span|br|wbr|ins|del|img)\\b)\\w+(?!:/|[^\\w\\s@]*@)\\b';
 
+block._comment = /<!--(?!-?>)[\s\S]*?-->/;
+
 block.html = replace(block.html)
   ('comment', /<!--[\s\S]*?-->/)
   ('closed', /<(tag)[\s\S]+?<\/\1>/)
@@ -488,7 +490,12 @@ var inline = {
   escape: /^\\([`*{}\[\]()#+\-.!_>|~]|\\(?!\w))/,
   autolink: /^<((?:[^ >]+(@|:\/)|www\d{0,3}\.)[^ >]+)>/,
   url: noop,
-  tag: /^<!--[\s\S]*?-->|^<\/?\w+(?:"[^"]*"|'[^']*'|[^'">])*?>/,
+  tag: '^comment'
+      + '|^</[a-zA-Z][\\w:-]*\\s*>' // self-closing tag
+      + '|^<[a-zA-Z][\\w-]*(?:attribute)*?\\s*/?>' // open tag
+      + '|^<\\?[\\s\\S]*?\\?>' // processing instruction, e.g. <?php ?>
+      + '|^<![a-zA-Z]+\\s[\\s\\S]*?>' // declaration, e.g. <!DOCTYPE html>
+      + '|^<!\\[CDATA\\[[\\s\\S]*?\\]\\]>', // CDATA section
   link: /^!?\[(inside)\]\((href)\)/,
   reflink: /^!?\[(inside)\]\s*\[([^\]]*)\]/,
   nolink: /^!?\[((?:\[[^\]]*\]|[^\[\]])*)\]/,
@@ -499,6 +506,13 @@ var inline = {
   del: noop,
   text: /^(`+|[^`])(?:[\s\S]*?(?:(?=[\\<!\[`*]|\b_|$)|[^ ](?= {2,}\n))|(?= {2,}\n))/
 };
+
+inline._attribute = /\s+[a-zA-Z:_][\w.:-]*(?:\s*=\s*"[^"]*"|\s*=\s*'[^']*'|\s*=\s*[^\s"'=<>`]+)?/;
+
+inline.tag = edit(inline.tag)
+    .replace('comment', block._comment)
+    .replace('attribute', inline._attribute)
+    .getRegex();
 
 // list of punctuation marks from common mark spec
 // without ` and ] to workaround Rule 17 (inline code blocks/links)

--- a/test/tests/links_reference_style.html
+++ b/test/tests/links_reference_style.html
@@ -50,3 +50,11 @@ breaks</a> across lines.</p>
 
 <p>Here&#39;s another where the <a href="/url/">link 
 breaks</a> across lines, but with a line-ending space.</p>
+
+<p>link pasted in HTML tag a &lt;a <a href="https://community.mattermost.com">&gt;</a> should work</p>
+
+<p>link pasted in HTML tag a with whitespace &lt; a <a href="https://community.mattermost.com">&gt;</a> should work</p>
+
+<p>link pasted in HTML tag span &lt;span <a href="https://community.mattermost.com">&gt;</a> should work</p>
+
+<p>link pasted in HTML tag span with whitespace &lt; span <a href="https://community.mattermost.com">&gt;</a> should work</p>

--- a/test/tests/links_reference_style.text
+++ b/test/tests/links_reference_style.text
@@ -69,3 +69,11 @@ breaks] across lines, but with a line-ending space.
 
 
 [link breaks]: /url/
+
+link pasted in HTML tag a <a [>](https://community.mattermost.com) should work
+
+link pasted in HTML tag a with whitespace < a [>](https://community.mattermost.com) should work
+
+link pasted in HTML tag span <span [>](https://community.mattermost.com) should work
+
+link pasted in HTML tag span with whitespace < span [>](https://community.mattermost.com) should work


### PR DESCRIPTION
#### Summary
Fixes rendering of links, when added to a string in this fashion:
`... this is random text <a [>](https://community.mattermost.com) ...`

#### Ticket Link
Fixes [MM-32645](https://mattermost.atlassian.net/browse/MM-32645)

#### expected result
<img width="370" alt="Screenshot 2021-02-10 at 15 30 07" src="https://user-images.githubusercontent.com/32863416/107523308-e11d2100-6bb4-11eb-8068-c4e394dd712c.png">

