### PR TITLE
MM-62744 Add urlFilter option for handling valid URL protocols

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -674,18 +674,21 @@ InlineLexer.prototype.output = function(src) {
           url = url.substring(0, url.length - 1);
       }
 
-      src = src.substring(url.length);
       text = escape(url);
       href = text;
 
-      tokens.push({
-        type: 'link',
-        text: text,
-        title: null,
-        href: href,
-        isUrl: true
-      });
-      continue;
+      if (this.options.urlFilter && this.options.urlFilter(url)) {
+        src = src.substring(url.length);
+
+        tokens.push({
+          type: 'link',
+          text: text,
+          title: null,
+          href: href,
+          isUrl: true
+        });
+        continue;
+      }
     }
 
     // tag

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -677,7 +677,7 @@ InlineLexer.prototype.output = function(src) {
       text = escape(url);
       href = text;
 
-      if (this.options.urlFilter && this.options.urlFilter(url)) {
+      if (this.options.urlFilter(url)) {
         src = src.substring(url.length);
 
         tokens.push({
@@ -1533,6 +1533,9 @@ marked.defaults = {
   renderer: new Renderer,
   xhtml: false,
   inlinelatex: false,
+  urlFilter() {
+    return true;
+  },
 };
 
 /**

--- a/test/index.js
+++ b/test/index.js
@@ -490,6 +490,38 @@ function parseArg(argv) {
     return arg;
   }
 
+  options.marked = {
+    urlFilter(url) {
+      url = url.toLowerCase();
+
+      const validPrefixes = [
+        // Allow links without protocols
+        'www.',
+        'www1.',
+
+        // Allow standard protocols
+        'http://',
+        'https://',
+
+        // Allow protocols expected by other tests
+        'asdf:',
+        'asdf://',
+        'asdf4://',
+        'taco+what://',
+        'taco.what://',
+        'test.:',
+      ];
+
+      for (const prefix of validPrefixes) {
+        if (url.startsWith(prefix)) {
+          return true;
+        }
+      }
+
+      return false;
+    },
+  };
+
   while (argv.length) {
     arg = getarg();
     switch (arg) {
@@ -524,7 +556,6 @@ function parseArg(argv) {
           if (!marked.defaults.hasOwnProperty(opt)) {
             continue;
           }
-          options.marked = options.marked || {};
           if (arg.indexOf('--no-') === 0) {
             options.marked[opt] = typeof marked.defaults[opt] !== 'boolean'
               ? null

--- a/test/tests/mm62744_remote_mention.html
+++ b/test/tests/mm62744_remote_mention.html
@@ -1,0 +1,9 @@
+<p>These links would be parsed as URLs if not for the urlFilter used for tests:</p>
+
+<p>@user:org</p>
+
+<p>This is a mention for @user1:org1.</p>
+
+<p>This is a mention for @user2:org/@user3:org1/@user4:org1.</p>
+
+<p>We need to mention User5 (@user5:org2)!</p>

--- a/test/tests/mm62744_remote_mention.text
+++ b/test/tests/mm62744_remote_mention.text
@@ -1,0 +1,9 @@
+These links would be parsed as URLs if not for the urlFilter used for tests:
+
+@user:org
+
+This is a mention for @user1:org1.
+
+This is a mention for @user2:org/@user3:org1/@user4:org1.
+
+We need to mention User5 (@user5:org2)!


### PR DESCRIPTION
#### Summary
This library is rather aggressive with autolinking to the point where it'll attempt to parse and render `foo:bar` as a link. Currently, the web app is responsible for preventing that from being rendered as a link, but that prevents anything that looks like it could be a link from going through regular text rendering which is needed for at-mentions.

This change is part of making the web app's Markdown library behave more like the Mobile app's one since this is how it handles not autolinking everything

#### Related Pull Requests
https://github.com/mattermost/mattermost/pull/32080

#### Ticket Link
MM-62744

